### PR TITLE
Document architecture and planning for GitHub Pages game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# overlap
-Three of four historical events or people overlapped, you must guess the impostor
+# Overlap
+
+A minimalist, terminal-inspired browser game where three of four historical events or people share an overlapping time period—and you have to spot the impostor. The project is being built to run entirely as a static site, making it ideal for deployment on GitHub Pages.
+
+## Project Status
+We are currently documenting the architecture and development plan before implementing the interactive game. No game assets or logic have been committed yet.
+
+## Key Requirements
+- **Static hosting:** All code must run client-side so the game can be published via GitHub Pages without additional infrastructure.
+- **Endless play:** Rounds continue indefinitely; the score increments for correct answers and decrements (or resets) for wrong answers.
+- **Immediate feedback:** When a guess is incorrect, the correct answer and relevant timeline details briefly display before the next round.
+- **Touch-friendly UI:** Despite the terminal aesthetic, controls must work well on both desktop and mobile browsers.
+- **Extensible data store:** Historical events, people, and inventions are stored in JSON files that can be expanded without code changes.
+
+## Documentation
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — High-level structure, runtime flow, and GitHub Pages considerations.
+- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) — JSON schema for the static content "database".
+- [`docs/DEVELOPMENT_PLAN.md`](docs/DEVELOPMENT_PLAN.md) — Roadmap for bringing the game to life.
+
+## Next Steps
+1. Scaffold the static site with HTML, CSS, and vanilla JavaScript modules.
+2. Implement data loading helpers that pull from `data/events.json` while running on GitHub Pages.
+3. Build the gameplay loop, score tracking, and feedback UI.
+4. Populate the dataset with verified historical entries.
+
+Contributions are welcome—please coordinate on documentation first to ensure new features align with the static hosting strategy.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture Overview
+
+## Goals
+- Deliver a fully client-side historical deduction game that runs without any server-side dependencies.
+- Ensure compatibility with GitHub Pages hosting; all assets must be static files.
+- Keep the interface lightweight and responsive so it is usable on both desktop and mobile browsers.
+- Maintain an extensible content "database" that can be updated without code changes.
+
+## High-Level Structure
+```
+overlap/
+├── index.html         # Entry point served by GitHub Pages
+├── assets/            # Static assets such as fonts and sounds (optional)
+├── data/              # JSON data files used as the content database
+├── src/
+│   ├── game.js        # Core game loop and UI bindings
+│   ├── data-store.js  # Data fetching and random selection helpers
+│   ├── ui.js          # Rendering and terminal-style interaction helpers
+│   └── state.js       # Score tracking and persistence (localStorage)
+├── styles/
+│   └── main.css       # Minimal terminal-inspired styles
+└── docs/              # Project documentation
+```
+
+All files will be shipped as static assets so the site can be deployed by copying the repository to the `gh-pages` branch or enabling Pages from the `main` branch.
+
+## Runtime Flow
+1. `index.html` loads the compiled (or raw) JavaScript modules via `<script type="module">` so bundling is optional.
+2. `data-store.js` fetches the JSON data (hosted locally in `data/events.json`). Because GitHub Pages serves static files, the fetch will be a relative HTTP request that works without CORS issues.
+3. The game loop requests four records at a time: three with overlapping date ranges and one outlier. Logic resides in `game.js` with helper utilities for determining overlaps.
+4. The UI renders to a single focusable container styled to mimic a terminal. Keyboard events (arrow keys/number keys) and pointer taps trigger selections.
+5. `state.js` maintains the score and streak information and persists it to `localStorage` so the game can continue indefinitely between sessions.
+6. When the player answers, the UI briefly displays the correct timeline information before loading the next prompt.
+
+## GitHub Pages Considerations
+- Avoid dynamic imports that rely on a build pipeline. Stick to ES modules or use a very small bundler step that outputs files into `/dist`.
+- All fetches must be relative paths (`./data/events.json`) to avoid mixed content issues.
+- If using any fonts or sounds, include them locally rather than pulling from external CDNs to reduce failure points.
+- Provide a `404.html` that mirrors `index.html` if client-side routing is added (not currently required).
+
+## Extensibility
+- Future data files can be split by theme (e.g., `data/science.json`, `data/politics.json`). A manifest file can describe which datasets to load.
+- Game modules should be written so they can accept injected data arrays, enabling unit tests without network requests.
+- Consider adding seed-based randomness later to facilitate shared challenges.
+
+## Testing Strategy
+- Unit tests for overlap logic and date parsing can run in a Node + Jest environment.
+- Integration tests with Playwright or Cypress can verify interactive behavior in headless browsers.
+- Continuous deployment via GitHub Actions can build (if necessary) and deploy to GitHub Pages after tests pass.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,73 @@
+# Data Model Specification
+
+The game relies on a small, file-based "database" that can be served as static JSON files on GitHub Pages. All content lives in the `data/` directory and is fetched at runtime.
+
+## Entities
+
+### TimelineItem
+Represents any selectable item that can appear in a round.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | ✅ | Unique identifier. Use a slug-friendly format (`"world-war-ii"`). |
+| `name` | `string` | ✅ | Display name shown to the player. |
+| `type` | `"event_range" \| "event_single" \| "person"` | ✅ | Determines how dates are interpreted. |
+| `start` | `string` | ✅ | ISO-like date (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`). For single-date events or people, this equals the key date (birth, invention, etc.). |
+| `end` | `string \| null` | ✅ | Only meaningful for `event_range` or people (death). Must be `null` for `event_single`. |
+| `blurb` | `string` | ✅ | Short sentence displayed when revealing the answer. |
+| `sources` | `string[]` | ❌ | Optional citations for future use. |
+
+### Dataset Manifest *(optional future enhancement)*
+Allows chunking content into thematic packs.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | ✅ | Identifier for the dataset. |
+| `name` | `string` | ✅ | Human-readable name. |
+| `items` | `string[]` | ✅ | List of `TimelineItem.id` values contained in this dataset. |
+
+## File Layout
+```
+data/
+├── events.json        # Primary dataset consumed by the game
+└── manifest.json      # Optional, lists multiple datasets
+```
+
+`events.json` contains an array of `TimelineItem` objects. Example:
+
+```json
+[
+  {
+    "id": "world-war-ii",
+    "name": "World War II",
+    "type": "event_range",
+    "start": "1939-09-01",
+    "end": "1945-09-02",
+    "blurb": "The global conflict involving the vast majority of the world's nations."
+  },
+  {
+    "id": "super-soaker",
+    "name": "Invention of the Super Soaker",
+    "type": "event_single",
+    "start": "1989-01-01",
+    "end": null,
+    "blurb": "Lonnie Johnson patented the iconic pressurized water gun in 1989."
+  }
+]
+```
+
+## Date Handling
+- Use ISO-8601-compatible strings so JavaScript's `Date` constructor or custom parsers can handle them reliably.
+- When only the year is known, pad with `-01-01` for `start` and `-12-31` for `end` during normalization.
+- People can use `start` for birth and `end` for death. When the death date is unknown, set `end` to `null` and treat them like a single-date event after their birth.
+
+## Overlap Logic Expectations
+- Convert `start` and `end` to numeric timestamps (e.g., milliseconds) after normalization.
+- A `event_single` is considered to occur on a single day; treat `end = start` when comparing ranges.
+- `event_range` overlaps if the ranges intersect: `max(startA, startB) <= min(endA, endB)`.
+- A person overlaps any event that intersects their lifespan.
+
+## Future Expansion
+- Additional metadata (`region`, `tags`, `difficulty`) can guide filtering or theming.
+- Localization fields (`name_localized`, `blurb_localized`) can support translations.
+- If dataset size grows large, split into multiple JSON files and lazy-load as needed.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -1,0 +1,38 @@
+# Development Plan
+
+This roadmap outlines how to move from an empty repository to a fully playable historical overlap game that runs on GitHub Pages.
+
+## Phase 1 — Project Scaffolding
+- [ ] Set up basic project structure described in `ARCHITECTURE.md`.
+- [ ] Create `index.html` with a focusable terminal-style container and placeholder text.
+- [ ] Add `styles/main.css` with minimal dark theme styling and responsive typography.
+- [ ] Implement `src/game.js` with a simple loop that displays static mocked data to validate UI interactions.
+- [ ] Add automated formatting/linting (Prettier + ESLint) configured to work with static hosting.
+
+## Phase 2 — Data Infrastructure
+- [ ] Create empty `data/events.json` following the schema in `DATA_MODEL.md`.
+- [ ] Implement `data-store.js` utilities:
+  - Fetch JSON files relative to the site root (compatible with GitHub Pages).
+  - Normalize dates into comparable numeric ranges.
+  - Provide helper functions to pull random combinations of overlapping + outlier items.
+- [ ] Write unit tests for overlap logic to ensure correctness before data is populated.
+
+## Phase 3 — Gameplay Loop
+- [ ] Render four items per round with touch-friendly buttons.
+- [ ] Highlight selection, validate correctness, and show brief explanation containing the correct timeline.
+- [ ] Track score, streak, and lifetime stats in memory and persist via `localStorage`.
+- [ ] Add subtle transitions/delays so the player can read the answer before the next round loads.
+- [ ] Provide accessibility affordances: keyboard navigation, ARIA live regions for feedback, high-contrast mode.
+
+## Phase 4 — Polish & Deployment
+- [ ] Add settings controls (mute sounds, toggle animations, reset score).
+- [ ] Include analytics hooks (optional) respecting user privacy.
+- [ ] Create a GitHub Actions workflow to lint/test and deploy to GitHub Pages.
+- [ ] Document deployment steps and maintenance notes in the README.
+- [ ] Populate initial dataset with a curated set of events and people.
+
+## Ongoing Considerations
+- Keep bundle size minimal (<100 KB gzipped) for fast mobile loads.
+- Treat dataset contributions like code: validate format via JSON schema or tests.
+- Consider progressive enhancement: the game should remain usable even if JavaScript is slow; provide loading states and error fallbacks.
+- Collect playtest feedback to iterate on difficulty balancing and UI clarity.


### PR DESCRIPTION
## Summary
- expand the README with the core requirements for a GitHub Pages-friendly terminal-style history game
- add architecture notes covering static hosting constraints, runtime flow, and extensibility plans
- document the JSON data model and a phased development roadmap to guide implementation

## Testing
- no tests were run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68c980cdaef4832287f6d4809170225d