### PR TITLE
Scaffold playable prototype with sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A minimalist, terminal-inspired browser game where three of four historical events or people share an overlapping time period—and you have to spot the impostor. The project is being built to run entirely as a static site, making it ideal for deployment on GitHub Pages.
 
 ## Project Status
-We are currently documenting the architecture and development plan before implementing the interactive game. No game assets or logic have been committed yet.
+The terminal-inspired shell of the game is now in place, complete with a lightweight gameplay loop, score tracking, and a sample
+dataset. Rounds are built entirely client-side from static JSON so the experience still works on GitHub Pages.
 
 ## Key Requirements
 - **Static hosting:** All code must run client-side so the game can be published via GitHub Pages without additional infrastructure.
@@ -18,9 +19,9 @@ We are currently documenting the architecture and development plan before implem
 - [`docs/DEVELOPMENT_PLAN.md`](docs/DEVELOPMENT_PLAN.md) — Roadmap for bringing the game to life.
 
 ## Next Steps
-1. Scaffold the static site with HTML, CSS, and vanilla JavaScript modules.
-2. Implement data loading helpers that pull from `data/events.json` while running on GitHub Pages.
-3. Build the gameplay loop, score tracking, and feedback UI.
-4. Populate the dataset with verified historical entries.
+1. Expand the UI polish and add accessibility refinements (ARIA live regions, reduced motion mode).
+2. Grow the data helpers to support difficulty tuning and future dataset packs.
+3. Layer in richer feedback (timeline visualizations, streak celebrations) and persistent settings.
+4. Curate and verify a larger historical dataset with citations.
 
 Contributions are welcome—please coordinate on documentation first to ensure new features align with the static hosting strategy.

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "katherine-johnson",
+    "name": "Katherine Johnson",
+    "type": "person",
+    "category": "Person — Mathematician",
+    "start": "1918-08-26",
+    "end": "2020-02-24",
+    "blurb": "NASA mathematician who calculated trajectories for Mercury and Apollo missions."
+  },
+  {
+    "id": "space-race",
+    "name": "Space Race",
+    "type": "event_range",
+    "category": "Geopolitics — Space Race",
+    "start": "1957-10-04",
+    "end": "1975-07-17",
+    "blurb": "Cold War competition between the United States and the Soviet Union for supremacy in spaceflight capabilities."
+  },
+  {
+    "id": "beatles-on-ed-sullivan",
+    "name": "The Beatles on Ed Sullivan",
+    "type": "event_single",
+    "category": "Pop Culture — Television",
+    "start": "1964-02-09",
+    "end": null,
+    "blurb": "The Beatles made their iconic American television debut, drawing an audience of 73 million viewers."
+  },
+  {
+    "id": "apollo-11-mission",
+    "name": "Apollo 11 Moon Landing",
+    "type": "event_range",
+    "category": "Space Exploration — Moon Landing",
+    "start": "1969-07-16",
+    "end": "1969-07-24",
+    "blurb": "Neil Armstrong, Buzz Aldrin, and Michael Collins completed the first crewed lunar landing."
+  },
+  {
+    "id": "steve-jobs",
+    "name": "Steve Jobs",
+    "type": "person",
+    "category": "Person — Entrepreneur",
+    "start": "1955-02-24",
+    "end": "2011-10-05",
+    "blurb": "Co-founder of Apple whose design vision helped popularize personal computing and smartphones."
+  },
+  {
+    "id": "personal-computer-boom",
+    "name": "Personal Computer Boom",
+    "type": "event_range",
+    "category": "Technology — Personal Computing",
+    "start": "1977-01-01",
+    "end": "1985-12-31",
+    "blurb": "Rapid adoption of affordable microcomputers such as the Apple II, IBM PC, and Commodore 64."
+  },
+  {
+    "id": "mtv-launch",
+    "name": "MTV Launches",
+    "type": "event_single",
+    "category": "Pop Culture — Music Television",
+    "start": "1981-08-01",
+    "end": null,
+    "blurb": "MTV began broadcasting music videos 24/7, reshaping global pop culture and the music industry."
+  },
+  {
+    "id": "nes-us-release",
+    "name": "NES Launches in North America",
+    "type": "event_range",
+    "category": "Gaming — Consoles",
+    "start": "1985-10-18",
+    "end": "1986-09-01",
+    "blurb": "Nintendo rolled out the Entertainment System across North America, reviving the video game industry."
+  },
+  {
+    "id": "amelia-earhart",
+    "name": "Amelia Earhart",
+    "type": "person",
+    "category": "Person — Aviator",
+    "start": "1897-07-24",
+    "end": "1937-07-02",
+    "blurb": "Aviation pioneer famed for solo flights across the Atlantic and record-setting aerial feats."
+  },
+  {
+    "id": "harlem-renaissance",
+    "name": "Harlem Renaissance",
+    "type": "event_range",
+    "category": "Arts — Cultural Movement",
+    "start": "1918-01-01",
+    "end": "1937-12-31",
+    "blurb": "A flourishing of African American arts, literature, and music centered in Harlem, New York."
+  },
+  {
+    "id": "talking-pictures-debut",
+    "name": "Debut of Talking Pictures",
+    "type": "event_single",
+    "category": "Technology — Film",
+    "start": "1927-10-06",
+    "end": null,
+    "blurb": "Warner Bros. released 'The Jazz Singer,' introducing synchronized sound to feature films."
+  },
+  {
+    "id": "ny-worlds-fair-1939",
+    "name": "1939 New York World's Fair",
+    "type": "event_range",
+    "category": "Events — World's Fair",
+    "start": "1939-04-30",
+    "end": "1940-10-27",
+    "blurb": "The fair showcased 'The World of Tomorrow' with futuristic technology and global pavilions."
+  },
+  {
+    "id": "tim-berners-lee",
+    "name": "Tim Berners-Lee",
+    "type": "person",
+    "category": "Person — Computer Scientist",
+    "start": "1955-06-08",
+    "end": "2023-12-31",
+    "blurb": "Inventor of the World Wide Web and advocate for an open, accessible internet."
+  },
+  {
+    "id": "dotcom-boom",
+    "name": "Dot-com Boom",
+    "type": "event_range",
+    "category": "Economy — Internet",
+    "start": "1995-01-01",
+    "end": "2001-03-10",
+    "blurb": "Period of massive growth and speculation in internet-based companies leading up to the 2001 crash."
+  },
+  {
+    "id": "google-founding",
+    "name": "Google Founded",
+    "type": "event_single",
+    "category": "Technology — Search",
+    "start": "1998-09-04",
+    "end": null,
+    "blurb": "Larry Page and Sergey Brin incorporated Google, launching a new era of web search."
+  },
+  {
+    "id": "facebook-launch",
+    "name": "Facebook Launches",
+    "type": "event_single",
+    "category": "Social Media — Networking",
+    "start": "2004-02-04",
+    "end": null,
+    "blurb": "Mark Zuckerberg and classmates opened Thefacebook to Harvard students, sparking rapid expansion."
+  },
+  {
+    "id": "leonardo-da-vinci",
+    "name": "Leonardo da Vinci",
+    "type": "person",
+    "category": "Person — Polymath",
+    "start": "1452-04-15",
+    "end": "1519-05-02",
+    "blurb": "Renaissance artist and inventor whose notebooks bridged art, science, and engineering."
+  },
+  {
+    "id": "italian-wars",
+    "name": "Italian Wars",
+    "type": "event_range",
+    "category": "Geopolitics — Italian Wars",
+    "start": "1494-01-01",
+    "end": "1559-04-03",
+    "blurb": "Series of conflicts among European powers vying for control of the Italian Peninsula."
+  },
+  {
+    "id": "sistine-chapel-ceiling",
+    "name": "Sistine Chapel Ceiling Painted",
+    "type": "event_range",
+    "category": "Art — Masterwork",
+    "start": "1508-05-10",
+    "end": "1512-10-31",
+    "blurb": "Michelangelo painted the Sistine Chapel ceiling, creating one of the most renowned artworks in history."
+  },
+  {
+    "id": "magellan-circumnavigation",
+    "name": "Magellan's Circumnavigation",
+    "type": "event_range",
+    "category": "Exploration — Voyages",
+    "start": "1519-08-10",
+    "end": "1522-09-06",
+    "blurb": "The expedition led by Ferdinand Magellan completed the first circumnavigation of the Earth."
+  }
+]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -7,10 +7,14 @@ The game relies on a small, file-based "database" that can be served as static J
 ### TimelineItem
 Represents any selectable item that can appear in a round.
 
+Categories are intentionally granular ("Person — Aviator", "Technology — Search") so that the round builder can pull a diverse
+mix of people, inventions, cultural moments, and geopolitical events for every game.
+
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `id` | `string` | ✅ | Unique identifier. Use a slug-friendly format (`"world-war-ii"`). |
 | `name` | `string` | ✅ | Display name shown to the player. |
+| `category` | `string` | ✅ | Domain grouping (e.g., "Person — Aviator", "Technology — Search") used to balance each round's options. |
 | `type` | `"event_range" \| "event_single" \| "person"` | ✅ | Determines how dates are interpreted. |
 | `start` | `string` | ✅ | ISO-like date (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`). For single-date events or people, this equals the key date (birth, invention, etc.). |
 | `end` | `string \| null` | ✅ | Only meaningful for `event_range` or people (death). Must be `null` for `event_single`. |
@@ -40,6 +44,7 @@ data/
   {
     "id": "world-war-ii",
     "name": "World War II",
+    "category": "Geopolitics — Global Conflict",
     "type": "event_range",
     "start": "1939-09-01",
     "end": "1945-09-02",
@@ -48,6 +53,7 @@ data/
   {
     "id": "super-soaker",
     "name": "Invention of the Super Soaker",
+    "category": "Invention — Toys",
     "type": "event_single",
     "start": "1989-01-01",
     "end": null,

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -3,15 +3,15 @@
 This roadmap outlines how to move from an empty repository to a fully playable historical overlap game that runs on GitHub Pages.
 
 ## Phase 1 — Project Scaffolding
-- [ ] Set up basic project structure described in `ARCHITECTURE.md`.
-- [ ] Create `index.html` with a focusable terminal-style container and placeholder text.
-- [ ] Add `styles/main.css` with minimal dark theme styling and responsive typography.
-- [ ] Implement `src/game.js` with a simple loop that displays static mocked data to validate UI interactions.
+- [x] Set up basic project structure described in `ARCHITECTURE.md`.
+- [x] Create `index.html` with a focusable terminal-style container and placeholder text.
+- [x] Add `styles/main.css` with minimal dark theme styling and responsive typography.
+- [x] Implement `src/game.js` with a simple loop that displays static mocked data to validate UI interactions.
 - [ ] Add automated formatting/linting (Prettier + ESLint) configured to work with static hosting.
 
 ## Phase 2 — Data Infrastructure
-- [ ] Create empty `data/events.json` following the schema in `DATA_MODEL.md`.
-- [ ] Implement `data-store.js` utilities:
+- [x] Create empty `data/events.json` following the schema in `DATA_MODEL.md`.
+- [x] Implement `data-store.js` utilities:
   - Fetch JSON files relative to the site root (compatible with GitHub Pages).
   - Normalize dates into comparable numeric ranges.
   - Provide helper functions to pull random combinations of overlapping + outlier items.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Overlap</title>
+    <link rel="stylesheet" href="./styles/main.css" />
+  </head>
+  <body>
+    <main class="terminal" id="app" tabindex="0">
+      <header class="terminal__header">
+        <h1 class="terminal__title">Overlap</h1>
+        <p class="terminal__subtitle">Find the timeline imposter.</p>
+      </header>
+      <section class="terminal__score" aria-live="polite">
+        <div>Round: <span id="round-counter">1</span></div>
+        <div>Score: <span id="score-counter">0</span></div>
+        <div>Streak: <span id="streak-counter">0</span></div>
+      </section>
+      <section class="terminal__prompt" aria-live="polite">
+        <p id="prompt-text">Loading timeline data…</p>
+      </section>
+      <section class="terminal__choices" id="choices" role="list">
+        <!-- Options injected by the UI module -->
+      </section>
+      <section class="terminal__feedback" aria-live="polite">
+        <p id="feedback-text"></p>
+      </section>
+      <footer class="terminal__footer">
+        <button id="next-round" class="terminal__button" hidden>Next round</button>
+      </footer>
+    </main>
+    <script type="module" src="./src/game.js"></script>
+  </body>
+</html>

--- a/src/data-store.js
+++ b/src/data-store.js
@@ -1,0 +1,209 @@
+const DATA_URL = './data/events.json';
+
+const DATE_REGEX = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/;
+
+function pad(value) {
+  return value.toString().padStart(2, '0');
+}
+
+function expandDate(dateString, { isEnd } = {}) {
+  if (!dateString) return null;
+  const match = DATE_REGEX.exec(dateString);
+  if (!match) {
+    throw new Error(`Invalid date string: ${dateString}`);
+  }
+
+  const year = Number(match[1]);
+  const month = match[2] ? Number(match[2]) : isEnd ? 12 : 1;
+  const day = match[3]
+    ? Number(match[3])
+    : isEnd
+    ? new Date(year, month, 0).getDate()
+    : 1;
+
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+function toTimestamp(dateString, { isEnd } = {}) {
+  if (!dateString) return null;
+  const fullDate = expandDate(dateString, { isEnd });
+  return new Date(`${fullDate}T00:00:00Z`).valueOf();
+}
+
+function normaliseItem(raw) {
+  const startTimestamp = toTimestamp(raw.start);
+  const effectiveEnd = raw.end ?? raw.start;
+  const endTimestamp = toTimestamp(effectiveEnd, { isEnd: true });
+
+  return {
+    ...raw,
+    category: raw.category ?? 'General',
+    startTimestamp,
+    endTimestamp,
+    duration: endTimestamp - startTimestamp,
+  };
+}
+
+function rangesOverlap(a, b) {
+  return a.startTimestamp <= b.endTimestamp && a.endTimestamp >= b.startTimestamp;
+}
+
+function intersectionRange(items) {
+  const start = Math.max(...items.map((item) => item.startTimestamp));
+  const end = Math.min(...items.map((item) => item.endTimestamp));
+  return { start, end };
+}
+
+function differenceFromRange(item, range) {
+  if (item.startTimestamp > range.end) {
+    return item.startTimestamp - range.end;
+  }
+  if (item.endTimestamp < range.start) {
+    return range.start - item.endTimestamp;
+  }
+  return 0;
+}
+
+function shuffle(items, rng = Math.random) {
+  const clone = [...items];
+  for (let i = clone.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [clone[i], clone[j]] = [clone[j], clone[i]];
+  }
+  return clone;
+}
+
+function getRandomItem(items, rng) {
+  return items[Math.floor(rng() * items.length)];
+}
+
+function findOverlappingTriple(items, rng = Math.random, attempts = 400) {
+  if (items.length < 3) return null;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const first = getRandomItem(items, rng);
+    const overlappingWithFirst = items.filter(
+      (item) => item.id !== first.id && item.category !== first.category && rangesOverlap(item, first),
+    );
+    if (overlappingWithFirst.length < 2) {
+      continue;
+    }
+
+    const second = getRandomItem(overlappingWithFirst, rng);
+    const overlappingBoth = items.filter((item) => {
+      if (item.id === first.id || item.id === second.id) return false;
+      if (item.category === first.category || item.category === second.category) return false;
+      return rangesOverlap(item, first) && rangesOverlap(item, second);
+    });
+
+    if (overlappingBoth.length === 0) {
+      continue;
+    }
+
+    const third = getRandomItem(overlappingBoth, rng);
+    const triple = [first, second, third];
+    const uniqueCategories = new Set(triple.map((item) => item.category));
+    const range = intersectionRange(triple);
+
+    if (uniqueCategories.size === triple.length && range.start <= range.end) {
+      return { triple, range };
+    }
+  }
+
+  return null;
+}
+
+function findOutlier(triple, range, items, rng = Math.random) {
+  const usedIds = new Set(triple.map((item) => item.id));
+  const usedCategories = new Set(triple.map((item) => item.category));
+  const candidates = items
+    .filter((item) => !usedIds.has(item.id) && !usedCategories.has(item.category))
+    .filter((item) => {
+      // Outlier must not overlap the intersection range shared by the triple
+      return item.startTimestamp > range.end || item.endTimestamp < range.start;
+    })
+    .map((item) => ({ item, gap: differenceFromRange(item, range) }))
+    .sort((a, b) => a.gap - b.gap);
+
+  if (candidates.length > 0) {
+    const tightestGap = candidates[0].gap;
+    const closest = candidates.filter((candidate) => candidate.gap === tightestGap);
+    return getRandomItem(closest.map((entry) => entry.item), rng);
+  }
+
+  // Fallback: relax the category constraint first
+  const relaxedCandidates = items
+    .filter((item) => !usedIds.has(item.id))
+    .filter((item) => item.startTimestamp > range.end || item.endTimestamp < range.start)
+    .map((item) => ({ item, gap: differenceFromRange(item, range) }))
+    .sort((a, b) => a.gap - b.gap);
+
+  if (relaxedCandidates.length > 0) {
+    return relaxedCandidates[0].item;
+  }
+
+  // Final fallback: pick any item not already used
+  const unused = items.filter((item) => !usedIds.has(item.id));
+  return unused.length ? getRandomItem(unused, rng) : null;
+}
+
+function formatYearRange(item) {
+  const start = new Date(item.startTimestamp);
+  const end = new Date(item.endTimestamp);
+  const startYear = start.getUTCFullYear();
+  const endYear = end.getUTCFullYear();
+
+  if (startYear === endYear) {
+    return `${startYear}`;
+  }
+  return `${startYear} – ${endYear}`;
+}
+
+export async function fetchTimelineItems(url = DATA_URL) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load data: ${response.status}`);
+  }
+  const payload = await response.json();
+  return payload.map(normaliseItem);
+}
+
+export function createRound(items, rng = Math.random) {
+  if (items.length < 4) {
+    throw new Error('At least four items are required to create a round.');
+  }
+
+  const overlapResult = findOverlappingTriple(items, rng);
+  if (!overlapResult) {
+    throw new Error('Unable to find overlapping timeline items for the round.');
+  }
+
+  const { triple, range } = overlapResult;
+  const outlier = findOutlier(triple, range, items, rng);
+  if (!outlier) {
+    throw new Error('Unable to determine an outlier item for this round.');
+  }
+
+  const options = shuffle([...triple, outlier], rng).map((item, index) => ({
+    ...item,
+    label: String.fromCharCode(65 + index),
+    yearRange: formatYearRange(item),
+  }));
+
+  return {
+    options,
+    answerId: outlier.id,
+    intersection: range,
+  };
+}
+
+export function describeIntersection(range) {
+  const start = new Date(range.start);
+  const end = new Date(range.end);
+  const startYear = start.getUTCFullYear();
+  const endYear = end.getUTCFullYear();
+  if (startYear === endYear) {
+    return `${startYear}`;
+  }
+  return `${startYear} – ${endYear}`;
+}

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,95 @@
+import { fetchTimelineItems, createRound, describeIntersection } from './data-store.js';
+import {
+  initUI,
+  renderRound,
+  markSelection,
+  revealAnswer,
+  lockChoices,
+  updateScoreboard,
+  setFeedback,
+  showError,
+} from './ui.js';
+import { getState, recordResult } from './state.js';
+
+let items = [];
+let currentRound = null;
+let awaitingSelection = false;
+
+function startNextRound() {
+  try {
+    currentRound = createRound(items);
+  } catch (error) {
+    showError(error.message);
+    console.error(error);
+    return;
+  }
+
+  const overlapDescription = describeIntersection(currentRound.intersection);
+  const state = getState();
+  renderRound({ options: currentRound.options, overlapDescription });
+  updateScoreboard({
+    round: state.round + 1,
+    score: state.score,
+    streak: state.streak,
+  });
+  setFeedback('Tap or press 1-4 to choose the imposter.');
+  awaitingSelection = true;
+}
+
+function handleSelection(choiceId) {
+  if (!awaitingSelection || !currentRound) return;
+  awaitingSelection = false;
+
+  markSelection(choiceId);
+
+  const selectedOption = currentRound.options.find((option) => option.id === choiceId);
+  const correctOption = currentRound.options.find((option) => option.id === currentRound.answerId);
+  const correct = choiceId === currentRound.answerId;
+
+  const resultState = recordResult({ correct });
+  updateScoreboard(resultState);
+
+  const overlapDescription = describeIntersection(currentRound.intersection);
+
+  let message = '';
+  if (correct) {
+    message = `Correct! ${correctOption.name} sits just outside the ${overlapDescription} overlap. ${correctOption.blurb}`;
+  } else {
+    message = `Not quite. ${correctOption.name} was the outlier beyond the ${overlapDescription} window. ${correctOption.blurb}`;
+  }
+
+  revealAnswer({
+    correctId: correctOption.id,
+    incorrectId: correct ? null : selectedOption?.id ?? null,
+    blurb: message,
+  });
+  lockChoices();
+}
+
+async function initialise() {
+  initUI({
+    onSelect: handleSelection,
+    onNext: () => {
+      if (!awaitingSelection) {
+        startNextRound();
+      }
+    },
+  });
+
+  const initialState = getState();
+  updateScoreboard({
+    round: initialState.round + 1,
+    score: initialState.score,
+    streak: initialState.streak,
+  });
+
+  try {
+    items = await fetchTimelineItems();
+    startNextRound();
+  } catch (error) {
+    console.error(error);
+    showError(error.message);
+  }
+}
+
+initialise();

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,69 @@
+const STORAGE_KEY = 'overlap-state-v1';
+
+const defaultState = () => ({
+  round: 0,
+  score: 0,
+  streak: 0,
+  bestStreak: 0,
+});
+
+function isStorageAvailable() {
+  try {
+    const key = '__storage_test__';
+    window.localStorage.setItem(key, '1');
+    window.localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+const storageEnabled = isStorageAvailable();
+
+function loadPersistedState() {
+  if (!storageEnabled) return defaultState();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState();
+    const parsed = JSON.parse(raw);
+    return { ...defaultState(), ...parsed };
+  } catch (error) {
+    console.warn('Failed to parse saved state, resetting.', error);
+    return defaultState();
+  }
+}
+
+let state = loadPersistedState();
+
+function persist() {
+  if (!storageEnabled) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('Unable to persist game state.', error);
+  }
+}
+
+export function getState() {
+  return { ...state };
+}
+
+export function recordResult({ correct }) {
+  state = {
+    ...state,
+    round: state.round + 1,
+    score: Math.max(0, state.score + (correct ? 1 : -1)),
+    streak: correct ? state.streak + 1 : 0,
+  };
+  if (state.streak > state.bestStreak) {
+    state.bestStreak = state.streak;
+  }
+  persist();
+  return getState();
+}
+
+export function resetState() {
+  state = defaultState();
+  persist();
+  return getState();
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,129 @@
+const promptText = document.getElementById('prompt-text');
+const choicesContainer = document.getElementById('choices');
+const feedbackText = document.getElementById('feedback-text');
+const roundCounter = document.getElementById('round-counter');
+const scoreCounter = document.getElementById('score-counter');
+const streakCounter = document.getElementById('streak-counter');
+const nextButton = document.getElementById('next-round');
+
+let selectHandler = null;
+let nextHandler = null;
+
+function clearChoices() {
+  choicesContainer.innerHTML = '';
+}
+
+function createChoiceElement(option) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'terminal__choice';
+  button.dataset.choiceId = option.id;
+  button.setAttribute('role', 'listitem');
+  button.setAttribute('aria-pressed', 'false');
+  button.innerHTML = `
+    <span class="terminal__choice-label">${option.label}</span>
+    <span class="terminal__choice-name">${option.name}</span>
+    <span class="terminal__choice-category">${option.category}</span>
+    <span class="terminal__choice-dates">${option.yearRange}</span>
+  `;
+  return button;
+}
+
+export function initUI({ onSelect, onNext }) {
+  selectHandler = onSelect;
+  nextHandler = onNext;
+
+  choicesContainer.addEventListener('click', (event) => {
+    const target = event.target.closest('[data-choice-id]');
+    if (!target || target.disabled) return;
+    if (selectHandler) {
+      selectHandler(target.dataset.choiceId);
+    }
+  });
+
+  choicesContainer.addEventListener('keydown', (event) => {
+    if (event.key >= '1' && event.key <= '4') {
+      const index = Number(event.key) - 1;
+      const button = choicesContainer.querySelectorAll('[data-choice-id]')[index];
+      if (button && !button.disabled) {
+        button.click();
+        event.preventDefault();
+      }
+    }
+  });
+
+  nextButton.addEventListener('click', () => {
+    if (nextHandler) nextHandler();
+  });
+}
+
+export function renderRound({ options, overlapDescription }) {
+  promptText.textContent = `Three entries overlap between ${overlapDescription}. Which one is the imposter?`;
+  clearChoices();
+  const fragment = document.createDocumentFragment();
+  options.forEach((option) => {
+    const element = createChoiceElement(option);
+    fragment.appendChild(element);
+  });
+  choicesContainer.appendChild(fragment);
+  feedbackText.textContent = '';
+  nextButton.hidden = true;
+  nextButton.disabled = true;
+  focusFirstChoice();
+}
+
+function focusFirstChoice() {
+  const first = choicesContainer.querySelector('[data-choice-id]');
+  if (first) {
+    first.focus({ preventScroll: true });
+  }
+}
+
+export function markSelection(choiceId) {
+  choicesContainer.querySelectorAll('[data-choice-id]').forEach((element) => {
+    const isSelected = element.dataset.choiceId === choiceId;
+    element.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+  });
+}
+
+export function revealAnswer({ correctId, incorrectId, blurb }) {
+  const correct = choicesContainer.querySelector(`[data-choice-id="${correctId}"]`);
+  if (correct) {
+    correct.classList.add('terminal__choice--correct');
+  }
+  if (incorrectId) {
+    const incorrect = choicesContainer.querySelector(`[data-choice-id="${incorrectId}"]`);
+    if (incorrect) {
+      incorrect.classList.add('terminal__choice--incorrect');
+    }
+  }
+  if (blurb) {
+    feedbackText.textContent = blurb;
+  }
+}
+
+export function lockChoices() {
+  choicesContainer.querySelectorAll('[data-choice-id]').forEach((element) => {
+    element.disabled = true;
+  });
+  nextButton.hidden = false;
+  nextButton.disabled = false;
+  nextButton.focus({ preventScroll: true });
+}
+
+export function updateScoreboard({ round, score, streak }) {
+  roundCounter.textContent = String(round);
+  scoreCounter.textContent = String(score);
+  streakCounter.textContent = String(streak);
+}
+
+export function setFeedback(message) {
+  feedbackText.textContent = message;
+}
+
+export function showError(message) {
+  promptText.textContent = 'An error occurred while loading the game.';
+  setFeedback(message);
+  clearChoices();
+  nextButton.hidden = true;
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,175 @@
+:root {
+  color-scheme: dark;
+  --terminal-bg: #0f172a;
+  --terminal-border: #1e293b;
+  --terminal-text: #e2e8f0;
+  --terminal-accent: #38bdf8;
+  --terminal-warn: #fbbf24;
+  --terminal-error: #f87171;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Fira Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background: radial-gradient(circle at top, #1e293b, #020617 60%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  color: var(--terminal-text);
+}
+
+main.terminal {
+  width: min(800px, 100%);
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid var(--terminal-border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  outline: none;
+  box-shadow: 0 16px 50px rgba(15, 23, 42, 0.45);
+}
+
+.terminal__header {
+  border-bottom: 1px solid var(--terminal-border);
+  padding-bottom: 0.75rem;
+}
+
+.terminal__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.terminal__subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.95rem;
+}
+
+.terminal__score {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.terminal__prompt p,
+.terminal__feedback p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.terminal__choices {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .terminal__choices {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.terminal__choice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem;
+  border: 1px solid var(--terminal-border);
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.55);
+  cursor: pointer;
+  transition: border-color 120ms ease, transform 120ms ease, background 120ms ease;
+}
+
+.terminal__choice:focus,
+.terminal__choice:hover {
+  border-color: var(--terminal-accent);
+  transform: translateY(-2px);
+  background: rgba(30, 41, 59, 0.9);
+}
+
+.terminal__choice[aria-pressed="true"] {
+  border-color: var(--terminal-accent);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.terminal__choice--correct {
+  border-color: #34d399;
+  background: rgba(52, 211, 153, 0.15);
+}
+
+.terminal__choice--incorrect {
+  border-color: var(--terminal-error);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.terminal__choice-label {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 0.75rem;
+}
+
+.terminal__choice-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.terminal__choice-dates {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.terminal__choice-category {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.terminal__feedback {
+  min-height: 2rem;
+  font-size: 0.95rem;
+}
+
+.terminal__button {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--terminal-accent);
+  color: #082f49;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  width: fit-content;
+  align-self: flex-end;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.terminal__button:focus,
+.terminal__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.3);
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 0.75rem;
+  }
+
+  main.terminal {
+    padding: 1.25rem;
+  }
+
+  .terminal__score {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the static Overlap shell with a terminal-inspired layout, scoreboard, and feedback controls
- implement data helpers, UI bindings, and state persistence so rounds can be generated client-side with tight outliers
- seed the project with a categorized sample dataset and document the updated data model and roadmap progress

## Testing
- Manual smoke test with `node --input-type=module` to sample `createRound` output


------
https://chatgpt.com/codex/tasks/task_e_68c984886914832297196c547e08019f